### PR TITLE
Fix rectangle selection command in tmux config

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -6,7 +6,7 @@ set-option -g mode-keys vi
 set-option -g status-position bottom
 
 bind-key -T copy-mode-vi v   send-keys -X begin-selection
-bind-key -T copy-mode-vi C-v send-keys -X rectangel-toggle
+bind-key -T copy-mode-vi C-v send-keys -X rectangle-toggle
 bind-key -T copy-mode-vi V   send-keys -X select-line
 bind-key -T copy-mode-vi y   send-keys -X copy-selection
 bind-key -T copy-mode-vi C-[ send-keys -X clear-selection


### PR DESCRIPTION
## Summary
- fix misspelled `rectangle-toggle` command in tmux config

## Testing
- `tmux -f .config/tmux/tmux.conf -L test new -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd8c4eeb883288bbfe58cc4f4bb20